### PR TITLE
Drop unnecessary example config.

### DIFF
--- a/bosh/secrets.example.yml
+++ b/bosh/secrets.example.yml
@@ -42,29 +42,12 @@ networks:
     subnet: subnet
   static:
   - <changme>
-  dns:
-  - <changeme>
   gateway: <changeme>
   reserved:
   - <changeme>
   range: <changeme>
 
 jobs:
-- name: broker
-  networks:
-  - name: default
-    static_ips:
-    - <changeme>
-- name: broker-registrar
-  networks:
-  - name: default
-    static_ips:
-    - <changeme>
-- name: broker-deregistrar
-  networks:
-  - name: default
-    static_ips:
-    - <changeme>
 - name: docker
   networks:
   - name: default


### PR DESCRIPTION
I looked at the bosh networking docs again and realized that I'd added a bunch of unnecessary example config earlier--we only want to set `static_ips` for the `docker` job, right?

cc @afeld @dlapiduz 
